### PR TITLE
Adds a space before each command so it doesn't show up in bash history

### DIFF
--- a/src/Prank.js
+++ b/src/Prank.js
@@ -24,7 +24,7 @@ const Prank = ({ name, description }) => (
         {description}
       </Typography>
 
-      <Copyable slug={name}>{`curl -L ${getBaseUrl()}/${name} | sh`}</Copyable>
+      <Copyable slug={name}>{` curl -L ${getBaseUrl()}/${name} | sh`}</Copyable>
     </CardContent>
   </Card>);
 


### PR DESCRIPTION
Adds a space before each command so it doesn't show up in bash history
Or we can do something like this:
`echo say .... ; history -d $((HISTCMD-1)`
🤷‍♂️ 